### PR TITLE
H3 ID Type Fix

### DIFF
--- a/lib/mappers/h3/h3.ex
+++ b/lib/mappers/h3/h3.ex
@@ -9,7 +9,7 @@ defmodule Mappers.H3 do
 
     # find h3 index
     h3_res9_id = :h3.from_geo({lat, lng}, 9)
-    h3_res9_id_s = Integer.to_string(h3_res9_id)
+    h3_res9_id_s = to_string(:h3.to_string(h3_res9_id))
 
     res9_temp = Repo.get(Res9, h3_res9_id_s)
 
@@ -25,7 +25,7 @@ defmodule Mappers.H3 do
     # check if h3 index exist in the db
     if res9_temp != nil do
       # record existing h3 res9 metric
-      :telemetry.execute([:ingest, :h3, :res9, :existing], %{h3_res9_id: h3_res9_id}, message)
+      :telemetry.execute([:ingest, :h3, :res9, :existing], %{h3_res9_id: h3_res9_id_s}, message)
 
       # IO.puts(res9_temp.geom)
       # IO.puts"here"
@@ -51,7 +51,7 @@ defmodule Mappers.H3 do
     else
       if :h3.is_valid(h3_res9_id) do
         # record new h3 res9 metric
-        :telemetry.execute([:ingest, :h3, :res9, :new], %{h3_res9_id: h3_res9_id}, message)
+        :telemetry.execute([:ingest, :h3, :res9, :new], %{h3_res9_id: h3_res9_id_s}, message)
 
         poly = :h3.to_geo_boundary(h3_res9_id)
         poly_length = length(poly)


### PR DESCRIPTION
This PR fixes the h3 id type to actually be a string. The Erlang h3 library being used was returning a char list which is not a binary type in Elixir.