### PR TITLE
Add Integer H3 Index Column

### DIFF
--- a/docker-martin/config.yaml
+++ b/docker-martin/config.yaml
@@ -29,6 +29,8 @@ table_sources:
     schema: public
     # table name
     table: h3_res9
+    # table source id column
+    id_column: h3_index_int
     # geometry column name
     geometry_column: geom
     # geometry srid
@@ -47,13 +49,15 @@ table_sources:
       state: string
       avg_rssi: double
       avg_snr: double
+      h3_index_int: int4
 
 # associative arrays of function sources
 function_sources:
-  public.function_source:
+  public.function_source_i:
     # function source id
-    id: public.function_source
+    id: public.function_source_i
     # schema name
     schema: public
     # function name
-    function: function_source
+    function: function_source_i
+

--- a/lib/mappers/h3/h3.ex
+++ b/lib/mappers/h3/h3.ex
@@ -70,6 +70,7 @@ defmodule Mappers.H3 do
             res9 =
               %{}
               |> Map.put(:id, h3_res9_id_s)
+              |> Map.put(:h3_index_int, h3_res9_id)
               |> Map.put(:state, "mapped")
               |> Map.put(:avg_rssi, rssi)
               |> Map.put(:avg_snr, snr)
@@ -99,6 +100,7 @@ defmodule Mappers.H3 do
             res9 =
               %{}
               |> Map.put(:id, h3_res9_id_s)
+              |> Map.put(:h3_index_int, h3_res9_id)
               |> Map.put(:state, "mapped")
               |> Map.put(:avg_rssi, rssi)
               |> Map.put(:avg_snr, snr)
@@ -129,6 +131,7 @@ defmodule Mappers.H3 do
             res9 =
               %{}
               |> Map.put(:id, h3_res9_id_s)
+              |> Map.put(:h3_index_int, h3_res9_id)
               |> Map.put(:state, "mapped")
               |> Map.put(:avg_rssi, rssi)
               |> Map.put(:avg_snr, snr)
@@ -160,6 +163,7 @@ defmodule Mappers.H3 do
             res9 =
               %{}
               |> Map.put(:id, h3_res9_id_s)
+              |> Map.put(:h3_index_int, h3_res9_id)
               |> Map.put(:state, "mapped")
               |> Map.put(:avg_rssi, rssi)
               |> Map.put(:avg_snr, snr)
@@ -192,6 +196,7 @@ defmodule Mappers.H3 do
             res9 =
               %{}
               |> Map.put(:id, h3_res9_id_s)
+              |> Map.put(:h3_index_int, h3_res9_id)
               |> Map.put(:state, "mapped")
               |> Map.put(:avg_rssi, rssi)
               |> Map.put(:avg_snr, snr)
@@ -225,6 +230,7 @@ defmodule Mappers.H3 do
             res9 =
               %{}
               |> Map.put(:id, h3_res9_id_s)
+              |> Map.put(:h3_index_int, h3_res9_id)
               |> Map.put(:state, "mapped")
               |> Map.put(:avg_rssi, rssi)
               |> Map.put(:avg_snr, snr)

--- a/lib/mappers/h3/res9.ex
+++ b/lib/mappers/h3/res9.ex
@@ -4,6 +4,7 @@ defmodule Mappers.H3.Res9 do
 
   @primary_key {:id, :string, []}
   schema "h3_res9" do
+    field :h3_index_int, :integer
     field :state, :string
     field :avg_rssi, :float
     field :avg_snr, :float
@@ -15,7 +16,7 @@ defmodule Mappers.H3.Res9 do
   @doc false
   def changeset(res9, attrs) do
     res9
-    |> cast(attrs, [:id, :state, :avg_rssi, :avg_snr, :geom])
-    |> validate_required([:id, :state, :avg_rssi, :avg_snr, :geom])
+    |> cast(attrs, [:id, :h3_index_int, :state, :avg_rssi, :avg_snr, :geom])
+    |> validate_required([:id, :h3_index_int, :state, :avg_rssi, :avg_snr, :geom])
   end
 end

--- a/priv/repo/migrations/20210118004207_create_h3_res9.exs
+++ b/priv/repo/migrations/20210118004207_create_h3_res9.exs
@@ -6,6 +6,7 @@ defmodule Mappers.Repo.Migrations.CreateH3Res9 do
 
     create table(:h3_res9, primary_key: false) do
       add :id, :string, primary_key: true
+      add :h3_index_int, :bigint
       add :state, :string
       add :avg_rssi, :float
       add :avg_snr, :float


### PR DESCRIPTION
This PR adds an integer h3 index column to the h3_res9 table for use as the feature id in the TileJSON that is produced by the tileserver.