### PR TITLE
Welcome modal and endpoint notice

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,4 @@ npm-debug.log
 
 #misc
 .env
+.DS_Store

--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -362,7 +362,7 @@ body {
   align-items: center;
   justify-content: center;
   
-  background-image: url("https://assets.codepen.io/69025/hexillo.svg");
+  background-image: url("https://helium-mappers.s3.us-west-2.amazonaws.com/hexillo.svg");
   background-position: 50% 0;
   background-repeat: no-repeat;
 }

--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -90,8 +90,7 @@ body {
   color: white;
   text-decoration: none;
 
-  font-size:16px;
-  color: white;
+  font-size: 1rem;
   
   padding: 0.75rem 0 0.75rem 0.75rem;
 }
@@ -265,11 +264,11 @@ body {
   width: 100%;
   /*min-width: 480px;*/
 }
-.hotspots-table thead {
+.hotspot-table-head {
   position: sticky;
   top: -0.25rem;
 }
-.hotspots-table thead th {
+.hotspot-table-head th {
   padding-bottom: 0.5rem;
 }
 .hotspots-table th, 
@@ -284,7 +283,6 @@ body {
 .hotspots-table td:last-child{
   padding-right: 0;
 }
-.hotspot-table-head {}
 .animal-cell {
   white-space: nowrap;
   overflow: hidden;
@@ -309,6 +307,77 @@ body {
 }
 /*end hotspots table*/
 /** end main stats stuff **/
+
+/** start welcome modal **/
+
+.modal {
+  position: fixed;
+      
+  box-sizing: border-box;
+  
+  color: white;
+
+  top: 50%;
+  left: 50%;
+  transform: translateX(-50%) translateY(calc(-50% - 2rem));
+  
+  padding: 0 2.25rem 2.5rem;
+  
+  width: 500px;
+
+  background: rgba(22, 23, 29, 0.9);
+  backdrop-filter: saturate(180%) blur(10px);
+  -webkit-backdrop-filter: saturate(180%) blur(10px);
+  
+  border-radius: 10px;
+  
+  z-index: 10;
+}
+
+.illo-header {
+  text-align: center;
+  
+  height: 250px;
+  max-height: 30vh; /*Keep things on screen, within reason*/
+  margin-bottom: 2rem;
+  
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  
+  background-image: url("https://assets.codepen.io/69025/hexillo.svg");
+  background-position: 50% 0;
+  background-repeat: no-repeat;
+}
+
+.modal-title {
+  font-weight: 600;
+  font-size: 1.75rem;
+  line-height: 125%;
+}
+.modal-copy {
+  font-weight: normal;
+  font-size: 1rem;
+  line-height: 155%;
+}
+.modal-copy a {
+  color: currentColor;
+  text-underline-offset: .125rem;
+}
+
+.modal-close {
+  position: absolute;
+  top: 1.5rem;
+  right: 1.5rem;
+}
+.modal-notice {
+  padding: 16px 24px;
+  color: #F1B0F7;
+  
+  border: 1px solid currentColor;
+  border-radius: 3px;
+}
+/** end welcome modal **/
 
  /*media queries*/
  @media only screen and (max-width: 550px) {
@@ -363,6 +432,22 @@ body {
   .hotspots-table-container {
     max-height: unset;
   }
+
+  /** start welcome modal **/
+  .modal {
+    width: 100vw;
+    
+    bottom: 0;
+    top: initial;
+    left: initial;
+    transform: unset;
+    
+    border-radius: 10px 10px 0 0;
+  }
+  .illo-header {
+    margin-bottom: 0;
+  }
+  /** end welcome modal **/
 
 }
 @media only screen and (max-width: 450px) {

--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -319,7 +319,7 @@ body {
 
   top: 50%;
   left: 50%;
-  transform: translateX(-50%) translateY(calc(-50% - 2rem));
+  transform: translateX(-50%) translateY(calc(-50% - 0.5rem));
   
   padding: 0 2.25rem 2.5rem;
   
@@ -332,6 +332,23 @@ body {
   border-radius: 10px;
   
   z-index: 10;
+}
+
+@media not prefers-reduced-motion {
+  .modal {
+    animation: 0.35s modalEntry 2s ease-out 1 backwards;
+  }
+}
+
+@keyframes modalEntry {
+  from {
+    opacity: 0;
+    transform: translateX(-50%) translateY(calc(-50% + 0.5rem));
+  }
+  to {
+    opacity: 1;
+    transform: translateX(-50%) translateY(calc(-50% - 0.5rem));
+  }
 }
 
 .illo-header {
@@ -441,6 +458,7 @@ body {
     top: initial;
     left: initial;
     transform: unset;
+    animation: none;
     
     border-radius: 10px 10px 0 0;
   }

--- a/assets/js/components/Map.js
+++ b/assets/js/components/Map.js
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { useState, useRef } from 'react';
 import MapGL, { Source, Layer, LinearInterpolator, WebMercatorViewport } from 'react-map-gl';
 import InfoPane from "../components/InfoPane"
+import WelcomeModal from "../components/WelcomeModal"
 import { uplinkTileServerLayer, hotspotTileServerLayer, uplinkHotspotsLineLayer, uplinkHotspotsCircleLayer, uplinkHotspotsHexLayer, uplinkChannelLayer} from './Layers.js';
 import bbox from '@turf/bbox';
 import { get } from '../data/Rest'
@@ -267,6 +268,7 @@ function Map() {
 
             </MapGL>
             <InfoPane hexId={hexId} avgRssi={avgRssi} avgSnr={avgSnr} uplinks={uplinks} showHexPane={showHexPane} onCloseHexPaneClick={onCloseHexPaneClick} />
+            <WelcomeModal/>
         </div>
     );
 }

--- a/assets/js/components/Map.js
+++ b/assets/js/components/Map.js
@@ -33,6 +33,10 @@ function Map() {
     const [avgSnr, setAvgSnr] = useState(null);
     const [showHexPane, setShowHexPane] = useState(false);
     const onCloseHexPaneClick = () => setShowHexPane(false);
+    const [showWelcomeModal, setShowWelcomeModal] = useState(true);
+    const onCloseWelcomeModalClick = () => setShowWelcomeModal(false);
+
+
 
     React.useEffect(() => {
         let features = []
@@ -268,7 +272,7 @@ function Map() {
 
             </MapGL>
             <InfoPane hexId={hexId} avgRssi={avgRssi} avgSnr={avgSnr} uplinks={uplinks} showHexPane={showHexPane} onCloseHexPaneClick={onCloseHexPaneClick} />
-            <WelcomeModal/>
+            <WelcomeModal showWelcomeModal={showWelcomeModal} onCloseWelcomeModalClick={onCloseWelcomeModalClick}/>
         </div>
     );
 }

--- a/assets/js/components/WelcomeModal.js
+++ b/assets/js/components/WelcomeModal.js
@@ -1,0 +1,11 @@
+import React from 'react'
+
+function WelcomeModal(props) {
+    // const [showLegendPane, setShowLegendPane] = React.useState(false)
+    // const onLegendClick = () => setShowLegendPane(!showLegendPane)
+    return (
+        <span>MERP</span>
+    )
+}
+
+export default WelcomeModal

--- a/assets/js/components/WelcomeModal.js
+++ b/assets/js/components/WelcomeModal.js
@@ -1,21 +1,27 @@
 import React from 'react'
 
 function WelcomeModal(props) {
-
+    const [showWelcomeModal, setshowWelcomeModal] = React.useState(true);
+    const onCloseWelcomeModalClick = () => showWelcomeModal(false);
+    
     return (
-        <div className="modal">
-            <div className="illo-header">
-                <h1 className="modal-title">Shape the future of Mappers</h1>
-            </div>
-            <button aria-label="Close intro window" className="close-button modal-close" type="button">
-                <svg className="icon" width="16" height="16" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg">
-                    <path d="M7.9998 6.54957L13.4284 1.12096C13.8289 0.720422 14.4783 0.720422 14.8789 1.12096C15.2794 1.5215 15.2794 2.1709 14.8789 2.57144L9.45028 8.00004L14.8789 13.4287C15.2794 13.8292 15.2794 14.4786 14.8789 14.8791C14.4783 15.2797 13.8289 15.2797 13.4284 14.8791L7.9998 9.45052L2.57119 14.8791C2.17065 15.2797 1.52125 15.2797 1.12072 14.8791C0.720178 14.4786 0.720178 13.8292 1.12072 13.4287L6.54932 8.00004L1.12072 2.57144C0.720178 2.1709 0.720178 1.5215 1.12072 1.12096C1.52125 0.720422 2.17065 0.720422 2.57119 1.12096L7.9998 6.54957Z"/>
-                </svg>
-            </button>
-            
-            <p className="modal-copy">We're getting the conversation started with this release. Your feedback is key in defining the features in the next evolution of this tool.</p>
-            <p className="modal-copy">Visit <a href="https://docs.helium.com/use-the-network/coverage-mapping" target="_blank">Docs</a> to find a few ways to give input or jump into <a href="https://github.com/helium/mappers" target="_blank">Github</a> to file an issue or contribute.</p>
-            <p className="modal-copy modal-notice"><strong>Notice:</strong> The Mappers submission endpoint will change on Monday, June 28. Update in under a minute with our <a href="https://docs.helium.com/use-the-network/coverage-mapping" target="_blank">migration guide.</a></p>
+        <div>
+            { props.showWelcomeModal &&
+                <div className="modal">
+                    <div className="illo-header">
+                        <h1 className="modal-title">Shape the future of Mappers</h1>
+                    </div>
+                    <button aria-label="Close intro window" className="close-button modal-close" type="button" onClick={props.onCloseWelcomeModalClick}>
+                        <svg className="icon" width="16" height="16" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg">
+                            <path d="M7.9998 6.54957L13.4284 1.12096C13.8289 0.720422 14.4783 0.720422 14.8789 1.12096C15.2794 1.5215 15.2794 2.1709 14.8789 2.57144L9.45028 8.00004L14.8789 13.4287C15.2794 13.8292 15.2794 14.4786 14.8789 14.8791C14.4783 15.2797 13.8289 15.2797 13.4284 14.8791L7.9998 9.45052L2.57119 14.8791C2.17065 15.2797 1.52125 15.2797 1.12072 14.8791C0.720178 14.4786 0.720178 13.8292 1.12072 13.4287L6.54932 8.00004L1.12072 2.57144C0.720178 2.1709 0.720178 1.5215 1.12072 1.12096C1.52125 0.720422 2.17065 0.720422 2.57119 1.12096L7.9998 6.54957Z"/>
+                        </svg>
+                    </button>
+                    
+                    <p className="modal-copy">We're getting the conversation started with this release. Your feedback is key in defining the features in the next evolution of this tool.</p>
+                    <p className="modal-copy">Visit <a href="https://docs.helium.com/use-the-network/coverage-mapping" target="_blank">Docs</a> to find a few ways to give input or jump into <a href="https://github.com/helium/mappers" target="_blank">Github</a> to file an issue or contribute.</p>
+                    <p className="modal-copy modal-notice"><strong>Notice:</strong> The Mappers submission endpoint will change on Monday, June 28. Update in under a minute with our <a href="https://docs.helium.com/use-the-network/coverage-mapping" target="_blank">migration guide.</a></p>
+                </div>
+            }
         </div>
     )
 }

--- a/assets/js/components/WelcomeModal.js
+++ b/assets/js/components/WelcomeModal.js
@@ -1,10 +1,22 @@
 import React from 'react'
 
 function WelcomeModal(props) {
-    // const [showLegendPane, setShowLegendPane] = React.useState(false)
-    // const onLegendClick = () => setShowLegendPane(!showLegendPane)
+
     return (
-        <span>MERP</span>
+        <div className="modal">
+            <div className="illo-header">
+                <h1 className="modal-title">Shape the future of Mappers</h1>
+            </div>
+            <button aria-label="Close intro window" className="close-button modal-close" type="button">
+                <svg className="icon" width="16" height="16" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg">
+                    <path d="M7.9998 6.54957L13.4284 1.12096C13.8289 0.720422 14.4783 0.720422 14.8789 1.12096C15.2794 1.5215 15.2794 2.1709 14.8789 2.57144L9.45028 8.00004L14.8789 13.4287C15.2794 13.8292 15.2794 14.4786 14.8789 14.8791C14.4783 15.2797 13.8289 15.2797 13.4284 14.8791L7.9998 9.45052L2.57119 14.8791C2.17065 15.2797 1.52125 15.2797 1.12072 14.8791C0.720178 14.4786 0.720178 13.8292 1.12072 13.4287L6.54932 8.00004L1.12072 2.57144C0.720178 2.1709 0.720178 1.5215 1.12072 1.12096C1.52125 0.720422 2.17065 0.720422 2.57119 1.12096L7.9998 6.54957Z"/>
+                </svg>
+            </button>
+            
+            <p className="modal-copy">We're getting the conversation started with this release. Your feedback is key in defining the features in the next evolution of this tool.</p>
+            <p className="modal-copy">Visit <a href="https://docs.helium.com/use-the-network/coverage-mapping" target="_blank">Docs</a> to find a few ways to give input or jump into <a href="https://github.com/helium/mappers" target="_blank">Github</a> to file an issue or contribute.</p>
+            <p className="modal-copy modal-notice"><strong>Notice:</strong> The Mappers submission endpoint will change on Monday, June 28. Update in under a minute with our <a href="https://docs.helium.com/use-the-network/coverage-mapping" target="_blank">migration guide.</a></p>
+        </div>
     )
 }
 

--- a/assets/js/components/WelcomeModal.js
+++ b/assets/js/components/WelcomeModal.js
@@ -19,7 +19,7 @@ function WelcomeModal(props) {
                     
                     <p className="modal-copy">We're getting the conversation started with this release. Your feedback is key in defining the features in the next evolution of this tool.</p>
                     <p className="modal-copy">Visit <a href="https://docs.helium.com/use-the-network/coverage-mapping" target="_blank">Docs</a> to find a few ways to give input or jump into <a href="https://github.com/helium/mappers" target="_blank">Github</a> to file an issue or contribute.</p>
-                    <p className="modal-copy modal-notice"><strong>Notice:</strong> The Mappers submission endpoint will change on Monday, June 28. Update in under a minute with our <a href="https://docs.helium.com/use-the-network/coverage-mapping" target="_blank">migration guide.</a></p>
+                    <p className="modal-copy modal-notice"><strong>Notice:</strong> The Mappers submission endpoint will change on Monday, June 28. Update in under a minute with our <a href="https://docs.helium.com/use-the-network/coverage-mapping/mappers-api/#ingest-uplink" target="_blank">migration guide.</a></p>
                 </div>
             }
         </div>


### PR DESCRIPTION
Closes #25 

This adds a dismissable welcome modal to mappers. The modal currently opens on each visit so I'd like to do a fast-follow with some functionality around remembering the state of the modal.

![Modal2](https://user-images.githubusercontent.com/1965053/122879532-db1b1780-d2ed-11eb-967c-9070eeaa67ad.gif)

TODO:
- [x] Serve background SVG locally. Webpack is currently complaining about `svg`
- [x] Set final route for endpoint change guide. Currently pointing to https://docs.helium.com/use-the-network/coverage-mapping