### PR TITLE
Adjust map layer colors.

### DIFF
--- a/assets/js/components/Layers.js
+++ b/assets/js/components/Layers.js
@@ -24,7 +24,7 @@ export const uplinkTileServerLayer = {
             ['boolean',
                 ['feature-state', 'selected'], true],
             'rgba(38,251,202,0.45)',
-            '#FFFFFF'
+            '#ffffff'
         ]
     }
 };
@@ -33,9 +33,9 @@ export const hotspotTileServerLayer = {
     id: 'public.h3_res8',
     type: 'fill',
     paint: {
-        'fill-color': '#414a4a',
+        'fill-color': '#ffffff',
         'fill-outline-color': '#fafbfd',
-        'fill-opacity': 0.2,
+        'fill-opacity': 0.15,
     }
 };
 
@@ -64,9 +64,9 @@ export const uplinkHotspotsHexLayer = {
     id: 'uplinkHotspotsHexLayer',
     type: 'fill',
     paint: {
-        'fill-color': '#414a4a',
-        'fill-outline-color': '#d8d51d',
-        'fill-opacity': 0.5,
+        'fill-color': '#a5a308',
+        'fill-outline-color': '#414a4a',
+        'fill-opacity': 0.45,
     }
 };
 
@@ -96,7 +96,7 @@ export const uplinkChannelLayer = {
             ['boolean',
                 ['feature-state', 'selected'], true],
             'rgba(38,251,202,0.45)',
-            '#FFFFFF'
+            '#ffffff'
         ]
     }
 };


### PR DESCRIPTION
Adjusts the hex colors for hotspots and witness hotspots to make them more visible and in-line with the colors referenced in the legend.

| Before  | After |
| ------------- | ------------- |
| ![image](https://user-images.githubusercontent.com/1965053/125567292-66c7f676-a9e3-4194-9736-a9587a713111.png) | ![image](https://user-images.githubusercontent.com/1965053/125567270-6446c88a-278f-48d4-b4fd-fa52b55a13ac.png) |

closes #68 