### PR TITLE
Remember closed state of modal.

### DIFF
--- a/assets/js/components/Map.js
+++ b/assets/js/components/Map.js
@@ -9,6 +9,7 @@ import { get } from '../data/Rest'
 import { geoToH3, h3ToGeo, h3ToGeoBoundary } from "h3-js";
 import socket from "../socket";
 import geojson2h3 from 'geojson2h3';
+import useLocalStorageState from 'use-local-storage-state';
 import '../../css/app.css';
 
 const MAPBOX_TOKEN = process.env.PUBLIC_MAPBOX_KEY;
@@ -33,7 +34,7 @@ function Map() {
     const [snr, setSnr] = useState(null);
     const [showHexPane, setShowHexPane] = useState(false);
     const onCloseHexPaneClick = () => setShowHexPane(false);
-    const [showWelcomeModal, setShowWelcomeModal] = useState(true);
+    const [showWelcomeModal, setShowWelcomeModal] = useLocalStorageState('welcomeModalOpen_v1', true);
     const onCloseWelcomeModalClick = () => setShowWelcomeModal(false);
 
 

--- a/assets/package.json
+++ b/assets/package.json
@@ -19,7 +19,8 @@
     "phoenix_html": "file:../deps/phoenix_html",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
-    "react-map-gl": "^6.1.15"
+    "react-map-gl": "^6.1.15",
+    "use-local-storage-state": "^10.0.0"
   },
   "devDependencies": {
     "@babel/core": "^7.0.0",

--- a/assets/yarn.lock
+++ b/assets/yarn.lock
@@ -6234,6 +6234,11 @@ url@^0.11.0:
     punycode "1.3.2"
     querystring "0.2.0"
 
+use-local-storage-state@^10.0.0:
+  version "10.0.0"
+  resolved "https://registry.yarnpkg.com/use-local-storage-state/-/use-local-storage-state-10.0.0.tgz#862d142e5d1fff30820102f0cd871e96e5527342"
+  integrity sha512-NCab0oYOMZA8oT9y4OE7tMT6JS21SiyPsTjZdapnyvHe7bVFlIMSp6LaiuHBdS1OvduuLtG+pX/duFIBkd0PCA==
+
 use@^3.1.0:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/use/-/use-3.1.1.tgz#d50c8cac79a19fbc20f2911f56eb973f4e10070f"


### PR DESCRIPTION
Uses localstorage to remember modal state.

I also tried to leverage localstorage to remember the coordinates of the user's last location (`lat`,`lng`), but I feel this behavior is probably better executed with session storage. I was also experiencing some funny behavior when opening the app in two tabs simultaneously.

There might be some argument to home-roll the storage extensions instead of use a 3rd party library, but for now this keeps the options open for leveraging localstorage for other attributes with an easy hook. Might be handy in the future.

![Screenflick Movie 3-2](https://user-images.githubusercontent.com/1965053/125832901-4eb2e788-3411-4abd-819c-9ebdaddd1773.gif)

closes #45 