### PR TITLE
Update to New Tileserver Endpoint [DNM]

### DIFF
--- a/assets/js/components/Map.js
+++ b/assets/js/components/Map.js
@@ -255,7 +255,7 @@ function Map() {
                 <Source id="hotspot-tileserver" type="vector" url={"https://hotspot-tileserver-martin.herokuapp.com/public.h3_res8.json"}>
                     <Layer {...hotspotTileServerLayer} source-layer={"public.h3_res8"} />
                 </Source>
-                <Source id="uplink-tileserver" type="vector" url={"http://mappers-tileserver-lb-439044836.us-west-2.elb.amazonaws.com/public.h3_res9.json"}>
+                <Source id="uplink-tileserver" type="vector" url={"https://mappers-tileserver-lb.helium.wtf/public.h3_res9.json"}>
                     <Layer {...uplinkTileServerLayer} source-layer={"public.h3_res9"} />
                 </Source>
                 <Source id="uplink-channel" type="geojson" data={uplinkChannelData}>

--- a/assets/js/components/Map.js
+++ b/assets/js/components/Map.js
@@ -255,7 +255,7 @@ function Map() {
                 <Source id="hotspot-tileserver" type="vector" url={"https://hotspot-tileserver-martin.herokuapp.com/public.h3_res8.json"}>
                     <Layer {...hotspotTileServerLayer} source-layer={"public.h3_res8"} />
                 </Source>
-                <Source id="uplink-tileserver" type="vector" url={"https://mappers-tileserver-martin.herokuapp.com/public.h3_res9.json"}>
+                <Source id="uplink-tileserver" type="vector" url={"https://d3spfrukkgeic1.cloudfront.net/public.h3_res9.json"}>
                     <Layer {...uplinkTileServerLayer} source-layer={"public.h3_res9"} />
                 </Source>
                 <Source id="uplink-channel" type="geojson" data={uplinkChannelData}>

--- a/assets/js/components/Map.js
+++ b/assets/js/components/Map.js
@@ -255,7 +255,7 @@ function Map() {
                 <Source id="hotspot-tileserver" type="vector" url={"https://hotspot-tileserver-martin.herokuapp.com/public.h3_res8.json"}>
                     <Layer {...hotspotTileServerLayer} source-layer={"public.h3_res8"} />
                 </Source>
-                <Source id="uplink-tileserver" type="vector" url={"https://d3spfrukkgeic1.cloudfront.net/public.h3_res9.json"}>
+                <Source id="uplink-tileserver" type="vector" url={"http://mappers-tileserver-lb-439044836.us-west-2.elb.amazonaws.com/public.h3_res9.json"}>
                     <Layer {...uplinkTileServerLayer} source-layer={"public.h3_res9"} />
                 </Source>
                 <Source id="uplink-channel" type="geojson" data={uplinkChannelData}>

--- a/assets/js/components/Map.js
+++ b/assets/js/components/Map.js
@@ -255,7 +255,7 @@ function Map() {
                 <Source id="hotspot-tileserver" type="vector" url={"https://hotspot-tileserver-martin.herokuapp.com/public.h3_res8.json"}>
                     <Layer {...hotspotTileServerLayer} source-layer={"public.h3_res8"} />
                 </Source>
-                <Source id="uplink-tileserver" type="vector" url={"http://d3spfrukkgeic1.cloudfront.net/public.h3_res9.json"}>
+                <Source id="uplink-tileserver" type="vector" url={"https://d3spfrukkgeic1.cloudfront.net/public.h3_res9.json"}>
                     <Layer {...uplinkTileServerLayer} source-layer={"public.h3_res9"} />
                 </Source>
                 <Source id="uplink-channel" type="geojson" data={uplinkChannelData}>

--- a/assets/js/components/Map.js
+++ b/assets/js/components/Map.js
@@ -255,7 +255,7 @@ function Map() {
                 <Source id="hotspot-tileserver" type="vector" url={"https://hotspot-tileserver-martin.herokuapp.com/public.h3_res8.json"}>
                     <Layer {...hotspotTileServerLayer} source-layer={"public.h3_res8"} />
                 </Source>
-                <Source id="uplink-tileserver" type="vector" url={"https://d3spfrukkgeic1.cloudfront.net/public.h3_res9.json"}>
+                <Source id="uplink-tileserver" type="vector" url={"http://d3spfrukkgeic1.cloudfront.net/public.h3_res9.json"}>
                     <Layer {...uplinkTileServerLayer} source-layer={"public.h3_res9"} />
                 </Source>
                 <Source id="uplink-channel" type="geojson" data={uplinkChannelData}>

--- a/assets/js/components/Map.js
+++ b/assets/js/components/Map.js
@@ -255,7 +255,7 @@ function Map() {
                 <Source id="hotspot-tileserver" type="vector" url={"https://hotspot-tileserver-martin.herokuapp.com/public.h3_res8.json"}>
                     <Layer {...hotspotTileServerLayer} source-layer={"public.h3_res8"} />
                 </Source>
-                <Source id="uplink-tileserver" type="vector" url={"https://mappers-tileserver-lb.helium.wtf/public.h3_res9.json"}>
+                <Source id="uplink-tileserver" type="vector" url={"https://mappers-tileserver.helium.wtf/public.h3_res9.json"}>
                     <Layer {...uplinkTileServerLayer} source-layer={"public.h3_res9"} />
                 </Source>
                 <Source id="uplink-channel" type="geojson" data={uplinkChannelData}>


### PR DESCRIPTION
This PR updates the mappers tileserver endpoint with an entirely new and improved hosting infrastructure. Originally the tileserver was hosted in a single region and querying the main mappers database every time someone loads the mappers site. Although this ensured the data was always the most fresh it could be, it was not scalable, and requests times suffered greatly when the site experienced high visitor counts. The new infrastructure is in multiple regions for redundancies, but mostly important it is now behind a global CDN with a 60 TTL cache. This will provide improved request latency for all our global users as well as allow for considerable spikes in visitors. 